### PR TITLE
fix: set spell slots by caster level

### DIFF
--- a/dndbeyond_json/js/app.js
+++ b/dndbeyond_json/js/app.js
@@ -1428,31 +1428,28 @@ const getPactMagicSlots = function(level) {
 
 function getSpellSlots(classes) {
     let isFullCaster = (className) => {
-        className = className.toLowerCase();
-        return (className == 'bard' || className == 'cleric' || className == 'druid' || className == 'sorcerer' || className == 'wizard');
+        return (className == 'Bard' || className == 'Cleric' || className == 'Druid' || className == 'Sorcerer' || className == 'Wizard');
     };
 
     let isHalfCaster = (className) => {
-        className = className.toLowerCase();
-        return (className == 'paladin' || className == 'ranger');
+        return (className == 'Paladin' || className == 'Ranger');
     }
 
     let isThirdCaster = (className, subclassName) => {
-        return (className == 'fighter' && subclassName == 'Eldritch Knight' || className == 'rogue' && subclassName == 'Arcane Trickster');
+        return (className == 'Fighter' && subclassName == 'Eldritch Knight' || className == 'Rogue' && subclassName == 'Arcane Trickster');
     }
 
     let casterLevel = 0;
 
     if (classes.length > 1 || isFullCaster(classes[0].definition.name)) {
         classes.some(function(current_class) {
-            className = current_class.definition.name.toLowerCase();
-            subclassName = current_class.subclassDefinition;
-
+            className = current_class.definition.name;
+            subclassName = (!!current_class.subclassDefinition) ? current_class.subclassDefinition.name : null;
             if (isFullCaster(className)) {
                 casterLevel += current_class.level;
             } else if (isHalfCaster(className)) {
                 casterLevel += Math.floor(current_class.level / 2);
-            } else if (isThirdCaster(className, subclassDefinition)) {
+            } else if (isThirdCaster(className, subclassName)) {
                 casterLevel += Math.floor(current_class.level / 3);
             }
         });
@@ -1470,11 +1467,11 @@ function getSpellSlots(classes) {
         casterLevel = classes[0].level;
 
         charSpellSlots1 = (casterLevel < 2) ? 0 : (casterLevel < 3) ? 2 : (casterLevel < 5) ? 3 : 4;
-        charSpellSlots2 = (casterLevel < 3) ? 0 : (casterLevel < 4) ? 2 : 3;
+        charSpellSlots2 = (casterLevel < 5) ? 0 : (casterLevel < 7) ? 2 : 3;
         charSpellSlots3 = (casterLevel < 9) ? 0 : (casterLevel < 11) ? 2 : 3;
         charSpellSlots4 = (casterLevel < 13) ? 0 : (casterLevel < 15) ? 1 : (casterLevel < 17) ? 2 : 3;
         charSpellSlots5 = (casterLevel < 17) ? 0 : (casterLevel < 19) ? 1 : 2;
-    } else if (isThirdCaster(classes[0].definition.name, classes[0].subclassDefinition)) {
+    } else if (isThirdCaster(classes[0].definition.name, (classes[0].subclassDefinition) ? classes[0].subclassDefinition.name : null)) {
         casterLevel = classes[0].level;
 
         charSpellSlots1 = (casterLevel < 3) ? 0 : (casterLevel < 4) ? 2 : (casterLevel < 7) ? 3 : 4;

--- a/dndbeyond_json/js/app.js
+++ b/dndbeyond_json/js/app.js
@@ -768,16 +768,10 @@ function parseCharacter(inputChar) {
         if(charClass === "warlock") {
             pactSlots = getPactMagicSlots(current_class.level);
             pactLevel = current_class.level;
-        } else {
-            if (current_class.hasOwnProperty("subclassDefinition")) {
-                if(current_class.subclassDefinition != null) {
-                    getSpellSlots(charClass, current_class.level, current_class.subclassDefinition.name);
-                }
-            } else {
-                getSpellSlots(charClass, current_class.level, null);
-            }
         }
     });
+
+    getSpellSlots(character.classes);
 
     buildXML += "\t\t<powermeta>\n";
     buildXML += "\t\t\t<pactmagicslots1>\n";
@@ -1432,294 +1426,61 @@ const getPactMagicSlots = function(level) {
     return 0;
 };
 
-function getSpellSlots(slotClass, slotLevel, slotSubClass) {
-    //console.log("Class: " + slotClass);
-    //console.log("Level: " + slotLevel);
-    if((slotClass === "bard") || (slotClass === "cleric") || (slotClass === "druid") || (slotClass === "sorcerer") || (slotClass === "wizard")) {
-        if (slotLevel == 1) {
-            charSpellSlots1 = 2;
-        } else if (slotLevel == 2) {
-            charSpellSlots1 = 3;
-        } else if (slotLevel == 3) {
-            charSpellSlots1 = 4;
-            charSpellSlots2 = 2;
-        } else if (slotLevel == 4) {
-            charSpellSlots1 = 4;
-            charSpellSlots2 = 3;
-        } else if (slotLevel == 5) {
-            charSpellSlots1 = 4;
-            charSpellSlots2 = 3;
-            charSpellSlots3 = 2;
-        } else if (slotLevel == 6) {
-            charSpellSlots1 = 4;
-            charSpellSlots2 = 3;
-            charSpellSlots3 = 3;
-        } else if (slotLevel == 7) {
-            charSpellSlots1 = 4;
-            charSpellSlots2 = 3;
-            charSpellSlots3 = 3;
-            charSpellSlots4 = 1;
-        } else if (slotLevel == 8) {
-            charSpellSlots1 = 4;
-            charSpellSlots2 = 3;
-            charSpellSlots3 = 3;
-            charSpellSlots4 = 2;
-        } else if (slotLevel == 9) {
-            charSpellSlots1 = 4;
-            charSpellSlots2 = 3;
-            charSpellSlots3 = 3;
-            charSpellSlots4 = 3;
-            charSpellSlots5 = 1;
-        } else if (slotLevel == 10) {
-            charSpellSlots1 = 4;
-            charSpellSlots2 = 3;
-            charSpellSlots3 = 3;
-            charSpellSlots4 = 3;
-            charSpellSlots5 = 2;
-        } else if (slotLevel == 11) {
-            charSpellSlots1 = 4;
-            charSpellSlots2 = 3;
-            charSpellSlots3 = 3;
-            charSpellSlots4 = 3;
-            charSpellSlots5 = 2;
-            charSpellSlots6 = 1;
-        } else if (slotLevel == 12) {
-            charSpellSlots1 = 4;
-            charSpellSlots2 = 3;
-            charSpellSlots3 = 3;
-            charSpellSlots4 = 3;
-            charSpellSlots5 = 2;
-            charSpellSlots6 = 1;
-        } else if (slotLevel == 13) {
-            charSpellSlots1 = 4;
-            charSpellSlots2 = 3;
-            charSpellSlots3 = 3;
-            charSpellSlots4 = 3;
-            charSpellSlots5 = 2;
-            charSpellSlots6 = 1;
-            charSpellSlots7 = 1;
-        } else if (slotLevel == 14) {
-            charSpellSlots1 = 4;
-            charSpellSlots2 = 3;
-            charSpellSlots3 = 3;
-            charSpellSlots4 = 3;
-            charSpellSlots5 = 2;
-            charSpellSlots6 = 1;
-            charSpellSlots7 = 1;
-        } else if (slotLevel == 15) {
-            charSpellSlots1 = 4;
-            charSpellSlots2 = 3;
-            charSpellSlots3 = 3;
-            charSpellSlots4 = 3;
-            charSpellSlots5 = 2;
-            charSpellSlots6 = 1;
-            charSpellSlots7 = 1;
-            charSpellSlots8 = 1;
-        } else if (slotLevel == 16) {
-            charSpellSlots1 = 4;
-            charSpellSlots2 = 3;
-            charSpellSlots3 = 3;
-            charSpellSlots4 = 3;
-            charSpellSlots5 = 2;
-            charSpellSlots6 = 1;
-            charSpellSlots7 = 1;
-            charSpellSlots8 = 1;
-        } else if (slotLevel == 17) {
-            charSpellSlots1 = 4;
-            charSpellSlots2 = 3;
-            charSpellSlots3 = 3;
-            charSpellSlots4 = 3;
-            charSpellSlots5 = 2;
-            charSpellSlots6 = 1;
-            charSpellSlots7 = 1;
-            charSpellSlots8 = 1;
-            charSpellSlots9 = 1;
-        } else if (slotLevel == 18) {
-            charSpellSlots1 = 4;
-            charSpellSlots2 = 3;
-            charSpellSlots3 = 3;
-            charSpellSlots4 = 3;
-            charSpellSlots5 = 3;
-            charSpellSlots6 = 1;
-            charSpellSlots7 = 1;
-            charSpellSlots8 = 1;
-            charSpellSlots9 = 1;
-        } else if (slotLevel == 19) {
-            charSpellSlots1 = 4;
-            charSpellSlots2 = 3;
-            charSpellSlots3 = 3;
-            charSpellSlots4 = 3;
-            charSpellSlots5 = 3;
-            charSpellSlots6 = 2;
-            charSpellSlots7 = 1;
-            charSpellSlots8 = 1;
-            charSpellSlots9 = 1;
-        } else if (slotLevel == 20) {
-            charSpellSlots1 = 4;
-            charSpellSlots2 = 3;
-            charSpellSlots3 = 3;
-            charSpellSlots4 = 3;
-            charSpellSlots5 = 3;
-            charSpellSlots6 = 2;
-            charSpellSlots7 = 2;
-            charSpellSlots8 = 1;
-            charSpellSlots9 = 1;
-        }
-    } else if(slotClass === "paladin" || slotClass === "ranger") {
-        if (slotLevel == 2) {
-            charSpellSlots1 = 2;
-        } else if (slotLevel == 3) {
-            charSpellSlots1 = 3;
-        } else if (slotLevel == 4) {
-            charSpellSlots1 = 3;
-        } else if (slotLevel == 5) {
-            charSpellSlots1 = 4;
-            charSpellSlots2 = 2;
-        } else if (slotLevel == 6) {
-            charSpellSlots1 = 4;
-            charSpellSlots2 = 2;
-        } else if (slotLevel == 7) {
-            charSpellSlots1 = 4;
-            charSpellSlots2 = 3;
-        } else if (slotLevel == 8) {
-            charSpellSlots1 = 4;
-            charSpellSlots2 = 3;
-        } else if (slotLevel == 9) {
-            charSpellSlots1 = 4;
-            charSpellSlots2 = 3;
-            charSpellSlots3 = 2;
-        } else if (slotLevel == 10) {
-            charSpellSlots1 = 4;
-            charSpellSlots2 = 3;
-            charSpellSlots3 = 2;
-        } else if (slotLevel == 11) {
-            charSpellSlots1 = 4;
-            charSpellSlots2 = 3;
-            charSpellSlots3 = 3;
-        } else if (slotLevel == 12) {
-            charSpellSlots1 = 4;
-            charSpellSlots2 = 3;
-            charSpellSlots3 = 3;
-        } else if (slotLevel == 13) {
-            charSpellSlots1 = 4;
-            charSpellSlots2 = 3;
-            charSpellSlots3 = 3;
-            charSpellSlots4 = 1;
-        } else if (slotLevel == 14) {
-            charSpellSlots1 = 4;
-            charSpellSlots2 = 3;
-            charSpellSlots3 = 3;
-            charSpellSlots4 = 1;
-        } else if (slotLevel == 15) {
-            charSpellSlots1 = 4;
-            charSpellSlots2 = 3;
-            charSpellSlots3 = 3;
-            charSpellSlots4 = 2;
-        } else if (slotLevel == 16) {
-            charSpellSlots1 = 4;
-            charSpellSlots2 = 3;
-            charSpellSlots3 = 3;
-            charSpellSlots4 = 2;
-        } else if (slotLevel == 17) {
-            charSpellSlots1 = 4;
-            charSpellSlots2 = 3;
-            charSpellSlots3 = 3;
-            charSpellSlots4 = 3;
-            charSpellSlots5 = 1;
-        } else if (slotLevel == 18) {
-            charSpellSlots1 = 4;
-            charSpellSlots2 = 3;
-            charSpellSlots3 = 3;
-            charSpellSlots4 = 3;
-            charSpellSlots5 = 1;
-        } else if (slotLevel == 19) {
-            charSpellSlots1 = 4;
-            charSpellSlots2 = 3;
-            charSpellSlots3 = 3;
-            charSpellSlots4 = 3;
-            charSpellSlots5 = 2;
-        } else if (slotLevel == 20) {
-            charSpellSlots1 = 4;
-            charSpellSlots2 = 3;
-            charSpellSlots3 = 3;
-            charSpellSlots4 = 3;
-            charSpellSlots5 = 2;
-        }
-    } else if((slotClass === "fighter" || slotClass === "rogue") && slotLevel >= 3 && slotSubClass != null) {
-        if(slotSubClass == "ArcaneTrickster" || slotSubClass == "Eldritch Knight") {
-            if (slotLevel == 3) {
-                charSpellSlots1 = 2;
-            } else if (slotLevel == 4) {
-                charSpellSlots1 = 3;
-            } else if (slotLevel == 5) {
-                charSpellSlots1 = 3;
-            } else if (slotLevel == 6) {
-                charSpellSlots1 = 3;
-            } else if (slotLevel == 7) {
-                charSpellSlots1 = 4;
-                charSpellSlots2 = 2;
-            } else if (slotLevel == 8) {
-                charSpellSlots1 = 4;
-                charSpellSlots2 = 2;
-            } else if (slotLevel == 9) {
-                charSpellSlots1 = 4;
-                charSpellSlots2 = 2;
-            } else if (slotLevel == 10) {
-                charSpellSlots1 = 4;
-                charSpellSlots2 = 3;
-            } else if (slotLevel == 11) {
-                charSpellSlots1 = 4;
-                charSpellSlots2 = 3;
-            } else if (slotLevel == 12) {
-                charSpellSlots1 = 4;
-                charSpellSlots2 = 3;
-                charSpellSlots3 = 3;
-            } else if (slotLevel == 13) {
-                charSpellSlots1 = 4;
-                charSpellSlots2 = 3;
-                charSpellSlots3 = 2;
-            } else if (slotLevel == 14) {
-                charSpellSlots1 = 4;
-                charSpellSlots2 = 3;
-                charSpellSlots3 = 2;
-            } else if (slotLevel == 15) {
-                charSpellSlots1 = 4;
-                charSpellSlots2 = 3;
-                charSpellSlots3 = 2;
-            } else if (slotLevel == 16) {
-                charSpellSlots1 = 4;
-                charSpellSlots2 = 3;
-                charSpellSlots3 = 3;
-            } else if (slotLevel == 17) {
-                charSpellSlots1 = 4;
-                charSpellSlots2 = 3;
-                charSpellSlots3 = 3;
-            } else if (slotLevel == 18) {
-                charSpellSlots1 = 4;
-                charSpellSlots2 = 3;
-                charSpellSlots3 = 3;
-            } else if (slotLevel == 19) {
-                charSpellSlots1 = 4;
-                charSpellSlots2 = 3;
-                charSpellSlots3 = 3;
-                charSpellSlots4 = 1;
-            } else if (slotLevel == 20) {
-                charSpellSlots1 = 4;
-                charSpellSlots2 = 3;
-                charSpellSlots3 = 3;
-                charSpellSlots4 = 1;
+function getSpellSlots(classes) {
+    let isFullCaster = (className) => {
+        className = className.toLowerCase();
+        return (className == 'bard' || className == 'cleric' || className == 'druid' || className == 'sorcerer' || className == 'wizard');
+    };
+
+    let isHalfCaster = (className) => {
+        className = className.toLowerCase();
+        return (className == 'paladin' || className == 'ranger');
+    }
+
+    let isThirdCaster = (className, subclassName) => {
+        return (className == 'fighter' && subclassName == 'Eldritch Knight' || className == 'rogue' && subclassName == 'Arcane Trickster');
+    }
+
+    let casterLevel = 0;
+
+    if (classes.length > 1 || isFullCaster(classes[0].definition.name)) {
+        classes.some(function(current_class) {
+            className = current_class.definition.name.toLowerCase();
+            subclassName = current_class.subclassDefinition;
+
+            if (isFullCaster(className)) {
+                casterLevel += current_class.level;
+            } else if (isHalfCaster(className)) {
+                casterLevel += Math.floor(current_class.level / 2);
+            } else if (isThirdCaster(className, subclassDefinition)) {
+                casterLevel += Math.floor(current_class.level / 3);
             }
-        }
-    } else {
-        //charSpellSlots1 = 0;
-        //charSpellSlots2 = 0;
-        //charSpellSlots3 = 0;
-        //charSpellSlots4 = 0;
-        //charSpellSlots5 = 0;
-        //charSpellSlots6 = 0;
-        //charSpellSlots7 = 0;
-        //charSpellSlots8 = 0;
-        //charSpellSlots9 = 0;
+        });
+
+        charSpellSlots1 = (casterLevel < 1) ? 0 : (casterLevel < 2) ? 2 : (casterLevel < 3) ? 3 : 4;
+        charSpellSlots2 = (casterLevel < 3) ? 0 : (casterLevel < 4) ? 2 : 3;
+        charSpellSlots3 = (casterLevel < 5) ? 0 : (casterLevel < 6) ? 2 : 3;
+        charSpellSlots4 = (casterLevel < 7) ? 0 : (casterLevel < 8) ? 1 : (casterLevel < 9) ? 2 : 3;
+        charSpellSlots5 = (casterLevel < 9) ? 0 : (casterLevel < 10) ? 1 : (casterLevel < 18) ? 2 : 3;
+        charSpellSlots6 = (casterLevel < 11) ? 0 : (casterLevel < 19) ? 1 : 2;
+        charSpellSlots7 = (casterLevel < 13) ? 0 : (casterLevel < 20) ? 1 : 2;
+        charSpellSlots8 = (casterLevel < 15) ? 0 : 1
+        charSpellSlots9 = (casterLevel < 17) ? 0 : 1;
+    } else if (isHalfCaster(classes[0].definition.name)) {
+        casterLevel = classes[0].level;
+
+        charSpellSlots1 = (casterLevel < 2) ? 0 : (casterLevel < 3) ? 2 : (casterLevel < 5) ? 3 : 4;
+        charSpellSlots2 = (casterLevel < 3) ? 0 : (casterLevel < 4) ? 2 : 3;
+        charSpellSlots3 = (casterLevel < 9) ? 0 : (casterLevel < 11) ? 2 : 3;
+        charSpellSlots4 = (casterLevel < 13) ? 0 : (casterLevel < 15) ? 1 : (casterLevel < 17) ? 2 : 3;
+        charSpellSlots5 = (casterLevel < 17) ? 0 : (casterLevel < 19) ? 1 : 2;
+    } else if (isThirdCaster(classes[0].definition.name, classes[0].subclassDefinition)) {
+        casterLevel = classes[0].level;
+
+        charSpellSlots1 = (casterLevel < 3) ? 0 : (casterLevel < 4) ? 2 : (casterLevel < 7) ? 3 : 4;
+        charSpellSlots2 = (casterLevel < 7) ? 0 : (casterLevel < 10) ? 2 : 3;
+        charSpellSlots3 = (casterLevel < 13) ? 0 : (casterLevel < 16) ? 2 : 3;
+        charSpellSlots4 = (casterLevel < 19) ? 0 : 1;
     }
 }
   


### PR DESCRIPTION
This new function should take into account multi-classing, half casters, and third casters.